### PR TITLE
Add Supabase endpoints for lessons and vocabulary materials

### DIFF
--- a/api/lessons/index.php
+++ b/api/lessons/index.php
@@ -1,0 +1,116 @@
+<?php
+require_once __DIR__ . '/../../config/config.php';
+require_once __DIR__ . '/../utils/error-handler.php';
+require_once __DIR__ . '/../utils/rate-limiter.php';
+
+header('Content-Type: application/json');
+
+if (ENVIRONMENT === 'development') {
+    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Methods: GET, POST, PUT, OPTIONS');
+    header('Access-Control-Allow-Headers: Content-Type, Authorization');
+    if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+        http_response_code(200);
+        exit;
+    }
+}
+
+try {
+    $method = $_SERVER['REQUEST_METHOD'];
+
+    $clientIP = $_SERVER['REMOTE_ADDR'];
+    $rateLimitKey = 'api:' . $clientIP;
+    $rateLimit = RateLimiter::check($rateLimitKey);
+    RateLimiter::applyHeaders($rateLimit);
+    if ($rateLimit['limited']) {
+        include __DIR__ . '/../../error-pages/429.php';
+        exit;
+    }
+
+    $data = [];
+    if ($method === 'GET') {
+        $data = $_GET;
+    } elseif (in_array($method, ['POST', 'PUT'])) {
+        $jsonInput = file_get_contents('php://input');
+        if (!empty($jsonInput)) {
+            $data = json_decode($jsonInput, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                ErrorHandler::handleError(400, 'Invalid JSON payload', [
+                    'error' => json_last_error_msg()
+                ]);
+            }
+        }
+    }
+
+    $data = Security::sanitizeInput($data);
+
+    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+    $token = '';
+    if (preg_match('/Bearer\s(\S+)/', $authHeader, $matches)) {
+        $token = $matches[1];
+    }
+    if (empty($token)) {
+        ErrorHandler::handleAuthError('Authentication token is required');
+    }
+
+    $supabase = SupabaseClient::createFromEnv();
+    $user = $supabase->verifyToken($token);
+    if (!$user) {
+        ErrorHandler::handleAuthError('Invalid or expired token');
+    }
+
+    switch ($method) {
+        case 'GET':
+            [$status, $payload] = $supabase->fetch('lessons');
+            http_response_code($status);
+            $response = [
+                'status' => $status === 200,
+                'data' => $payload
+            ];
+            break;
+
+        case 'POST':
+            $required = ['title'];
+            $errors = [];
+            foreach ($required as $field) {
+                if (empty($data[$field])) {
+                    $errors[$field] = 'This field is required';
+                }
+            }
+            if (!empty($errors)) {
+                ErrorHandler::handleValidationError($errors);
+            }
+            [$status, $payload] = $supabase->insert('lessons', [$data]);
+            http_response_code($status);
+            $response = [
+                'status' => in_array($status, [200, 201]),
+                'data' => $payload
+            ];
+            break;
+
+        case 'PUT':
+            if (empty($data['id'])) {
+                ErrorHandler::handleValidationError(['id' => 'ID is required for updates']);
+            }
+            $id = $data['id'];
+            unset($data['id']);
+            [$status, $payload] = $supabase->update('lessons', $id, $data);
+            http_response_code($status);
+            $response = [
+                'status' => $status === 200,
+                'data' => $payload
+            ];
+            break;
+
+        default:
+            ErrorHandler::handleError(405, 'Method Not Allowed');
+    }
+
+    echo json_encode($response);
+} catch (PDOException $e) {
+    ErrorHandler::handleDbError($e);
+} catch (Exception $e) {
+    ErrorHandler::handleError(500, 'Internal Server Error', [
+        'message' => ENVIRONMENT === 'development' ? $e->getMessage() : null
+    ]);
+}

--- a/api/vocabulary/index.php
+++ b/api/vocabulary/index.php
@@ -1,0 +1,120 @@
+<?php
+require_once __DIR__ . '/../../config/config.php';
+require_once __DIR__ . '/../utils/error-handler.php';
+require_once __DIR__ . '/../utils/rate-limiter.php';
+
+header('Content-Type: application/json');
+
+if (ENVIRONMENT === 'development') {
+    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Methods: GET, POST, PUT, OPTIONS');
+    header('Access-Control-Allow-Headers: Content-Type, Authorization');
+    if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+        http_response_code(200);
+        exit;
+    }
+}
+
+try {
+    $method = $_SERVER['REQUEST_METHOD'];
+
+    $clientIP = $_SERVER['REMOTE_ADDR'];
+    $rateLimitKey = 'api:' . $clientIP;
+    $rateLimit = RateLimiter::check($rateLimitKey);
+    RateLimiter::applyHeaders($rateLimit);
+    if ($rateLimit['limited']) {
+        include __DIR__ . '/../../error-pages/429.php';
+        exit;
+    }
+
+    $data = [];
+    if ($method === 'GET') {
+        $data = $_GET;
+    } elseif (in_array($method, ['POST', 'PUT'])) {
+        $jsonInput = file_get_contents('php://input');
+        if (!empty($jsonInput)) {
+            $data = json_decode($jsonInput, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                ErrorHandler::handleError(400, 'Invalid JSON payload', [
+                    'error' => json_last_error_msg()
+                ]);
+            }
+        }
+    }
+
+    $data = Security::sanitizeInput($data);
+
+    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+    $token = '';
+    if (preg_match('/Bearer\s(\S+)/', $authHeader, $matches)) {
+        $token = $matches[1];
+    }
+    if (empty($token)) {
+        ErrorHandler::handleAuthError('Authentication token is required');
+    }
+
+    $supabase = SupabaseClient::createFromEnv();
+    $user = $supabase->verifyToken($token);
+    if (!$user) {
+        ErrorHandler::handleAuthError('Invalid or expired token');
+    }
+
+    switch ($method) {
+        case 'GET':
+            $query = [];
+            if (!empty($data['lesson_id'])) {
+                $query['lesson_id'] = 'eq.' . $data['lesson_id'];
+            }
+            [$status, $payload] = $supabase->fetch('vocabulary', $query);
+            http_response_code($status);
+            $response = [
+                'status' => $status === 200,
+                'data' => $payload
+            ];
+            break;
+
+        case 'POST':
+            $required = ['term', 'lesson_id'];
+            $errors = [];
+            foreach ($required as $field) {
+                if (empty($data[$field])) {
+                    $errors[$field] = 'This field is required';
+                }
+            }
+            if (!empty($errors)) {
+                ErrorHandler::handleValidationError($errors);
+            }
+            [$status, $payload] = $supabase->insert('vocabulary', [$data]);
+            http_response_code($status);
+            $response = [
+                'status' => in_array($status, [200, 201]),
+                'data' => $payload
+            ];
+            break;
+
+        case 'PUT':
+            if (empty($data['id'])) {
+                ErrorHandler::handleValidationError(['id' => 'ID is required for updates']);
+            }
+            $id = $data['id'];
+            unset($data['id']);
+            [$status, $payload] = $supabase->update('vocabulary', $id, $data);
+            http_response_code($status);
+            $response = [
+                'status' => $status === 200,
+                'data' => $payload
+            ];
+            break;
+
+        default:
+            ErrorHandler::handleError(405, 'Method Not Allowed');
+    }
+
+    echo json_encode($response);
+} catch (PDOException $e) {
+    ErrorHandler::handleDbError($e);
+} catch (Exception $e) {
+    ErrorHandler::handleError(500, 'Internal Server Error', [
+        'message' => ENVIRONMENT === 'development' ? $e->getMessage() : null
+    ]);
+}

--- a/classes/SupabaseClient.php
+++ b/classes/SupabaseClient.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Minimal Supabase client for server-side requests
+ */
+class SupabaseClient {
+    private string $url;
+    private string $serviceKey;
+
+    public function __construct(string $url, string $serviceKey) {
+        $this->url = rtrim($url, '/');
+        $this->serviceKey = $serviceKey;
+    }
+
+    public static function createFromEnv(): self {
+        $url = getenv('SUPABASE_URL');
+        $key = getenv('SUPABASE_SERVICE_KEY');
+        if (empty($url) || empty($key)) {
+            throw new Exception('Supabase environment variables not set');
+        }
+        return new self($url, $key);
+    }
+
+    /** Verify an access token with Supabase auth */
+    public function verifyToken(string $token) {
+        $ch = curl_init("{$this->url}/auth/v1/user");
+        curl_setopt_array($ch, [
+            CURLOPT_HTTPHEADER => [
+                'Authorization: Bearer ' . $token,
+                'apikey: ' . $this->serviceKey
+            ],
+            CURLOPT_RETURNTRANSFER => true
+        ]);
+        $response = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        if ($status === 200) {
+            return json_decode($response, true);
+        }
+        return false;
+    }
+
+    /** Internal request helper for REST API */
+    private function request(string $method, string $path, ?array $body = null): array {
+        $ch = curl_init("{$this->url}/rest/v1/{$path}");
+        $headers = [
+            'apikey: ' . $this->serviceKey,
+            'Authorization: Bearer ' . $this->serviceKey,
+            'Content-Type: application/json',
+            'Prefer: return=representation'
+        ];
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        if ($body !== null) {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body));
+        }
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        $response = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        return [$status, json_decode($response, true)];
+    }
+
+    public function fetch(string $table, array $query = []): array {
+        $params = http_build_query($query);
+        $path = $table . ($params ? '?' . $params : '');
+        return $this->request('GET', $path);
+    }
+
+    public function insert(string $table, array $data): array {
+        return $this->request('POST', $table, $data);
+    }
+
+    public function update(string $table, string $id, array $data): array {
+        $path = $table . '?id=eq.' . urlencode($id);
+        return $this->request('PATCH', $path, $data);
+    }
+}

--- a/fsp_supabase_schema.sql
+++ b/fsp_supabase_schema.sql
@@ -1,0 +1,20 @@
+-- Supabase schema for FSP/Kenntnisprüfung content
+-- Lessons table
+create table if not exists lessons (
+    id uuid primary key default uuid_generate_v4(),
+    title text not null,
+    description text,
+    created_at timestamptz default timezone('utc', now()),
+    updated_at timestamptz default timezone('utc', now())
+);
+
+-- Vocabulary table
+create table if not exists vocabulary (
+    id uuid primary key default uuid_generate_v4(),
+    lesson_id uuid references lessons(id) on delete cascade,
+    term text not null,
+    definition text,
+    language text default 'de',
+    created_at timestamptz default timezone('utc', now()),
+    updated_at timestamptz default timezone('utc', now())
+);


### PR DESCRIPTION
## Summary
- define Supabase schema for `lessons` and `vocabulary` tables
- add PHP SupabaseClient to verify tokens and query Supabase REST
- implement secure endpoints to fetch and update lessons and vocabulary

## Testing
- `composer dump-autoload`
- `php -l classes/SupabaseClient.php`
- `php -l api/lessons/index.php`
- `php -l api/vocabulary/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6896bc5ba990832d82f514e8ca8a9908